### PR TITLE
Enabling usage of platform specific sdk for winforms and wpf

### DIFF
--- a/src/NUnitFramework/tests/SynchronizationContextTests.cs
+++ b/src/NUnitFramework/tests/SynchronizationContextTests.cs
@@ -104,7 +104,7 @@ namespace NUnit.Framework
             });
         }
 
-#if !NETCOREAPP2_1
+#if UseWindowsFormsAndWPF || NETFRAMEWORK
         // TODO: test a custom awaitable type whose awaiter executes continuations on a brand new thread
         // to ensure that the message pump is shut down on the correct thread.
 

--- a/src/NUnitFramework/tests/SynchronizationContextTests.cs
+++ b/src/NUnitFramework/tests/SynchronizationContextTests.cs
@@ -104,7 +104,7 @@ namespace NUnit.Framework
             });
         }
 
-#if UseWindowsFormsAndWPF || NETFRAMEWORK
+#if UseWindowsFormsAndWPF
         // TODO: test a custom awaitable type whose awaiter executes continuations on a brand new thread
         // to ensure that the message pump is shut down on the correct thread.
 

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -1,4 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project>
+  <PropertyGroup>
+    <UseWindowsFormsAndWPF>false</UseWindowsFormsAndWPF>
+    <UseWindowsFormsAndWPF Condition="'$(OS)' == 'Windows_NT' and '$(TargetFramework)' != 'netcoreapp2.1'">true</UseWindowsFormsAndWPF>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition="$(UseWindowsFormsAndWPF) == false" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Condition="$(UseWindowsFormsAndWPF)" />
 
   <PropertyGroup>
     <TargetFrameworks>net35;net40;net45;net46;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
@@ -11,11 +17,15 @@
     <!-- Microsoft.Bcl.Build workaround https://github.com/nunit/nunit/issues/2663 -->
     <SkipValidatePackageReferences>true</SkipValidatePackageReferences>
 
-    <UseWindowsForms>true</UseWindowsForms>
-    <UseWPF>true</UseWPF>
-
     <!-- Suppress Microsoft.NET.Sdk.WindowsDesktop warning that netcoreapp2.1 doesn't support desktop applications -->
-    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);NETSDK1105</MSBuildWarningsAsMessages>
+    <!--<MSBuildWarningsAsMessages Condition="'$(TargetFramework)' == 'netcoreapp2.1'">$(MSBuildWarningsAsMessages);NETSDK1105</MSBuildWarningsAsMessages>-->
+  </PropertyGroup>
+
+  <!-- Decide if we can use windows forms and wpf -->
+  <PropertyGroup Condition="$(UseWindowsFormsAndWPF)">
+      <DefineConstants>$(DefineConstants);UseWindowsFormsAndWPF</DefineConstants>
+      <UseWindowsForms>true</UseWindowsForms>
+      <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
@@ -44,6 +54,8 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Web" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
 
   <ItemGroup>
@@ -65,4 +77,6 @@
     <ProjectCapability Include="TestContainer" />
   </ItemGroup>
 
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition="$(UseWindowsFormsAndWPF) == false" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Condition="$(UseWindowsFormsAndWPF)" />
 </Project>

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -1,10 +1,12 @@
 ﻿<Project>
-  <PropertyGroup>
-    <UseWindowsFormsAndWPF>false</UseWindowsFormsAndWPF>
-    <UseWindowsFormsAndWPF Condition="'$(OS)' == 'Windows_NT' and '$(TargetFramework)' != 'netcoreapp2.1'">true</UseWindowsFormsAndWPF>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT' and '$(TargetFramework)' != 'netcoreapp2.1'">
+    <UseWindowsFormsAndWPF>true</UseWindowsFormsAndWPF>
+    <DefineConstants>$(DefineConstants);UseWindowsFormsAndWPF</DefineConstants>
+    <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition="$(UseWindowsFormsAndWPF) == false" />
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Condition="$(UseWindowsFormsAndWPF)" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition="'$(UseWindowsFormsAndWPF)' != 'true'" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Condition="'$(UseWindowsFormsAndWPF)' == 'true'" />
 
   <PropertyGroup>
     <TargetFrameworks>net35;net40;net45;net46;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
@@ -16,13 +18,6 @@
 
     <!-- Microsoft.Bcl.Build workaround https://github.com/nunit/nunit/issues/2663 -->
     <SkipValidatePackageReferences>true</SkipValidatePackageReferences>
-  </PropertyGroup>
-
-  <!-- Decide if we can use windows forms and wpf -->
-  <PropertyGroup Condition="$(UseWindowsFormsAndWPF)">
-      <DefineConstants>$(DefineConstants);UseWindowsFormsAndWPF</DefineConstants>
-      <UseWindowsForms>true</UseWindowsForms>
-      <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
@@ -51,8 +46,6 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Web" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="WindowsBase" />
   </ItemGroup>
 
   <ItemGroup>
@@ -74,6 +67,6 @@
     <ProjectCapability Include="TestContainer" />
   </ItemGroup>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition="$(UseWindowsFormsAndWPF) == false" />
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Condition="$(UseWindowsFormsAndWPF)" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition="'$(UseWindowsFormsAndWPF)' != 'true'" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Condition="'$(UseWindowsFormsAndWPF)' == 'true'" />
 </Project>

--- a/src/NUnitFramework/tests/nunit.framework.tests.csproj
+++ b/src/NUnitFramework/tests/nunit.framework.tests.csproj
@@ -16,9 +16,6 @@
 
     <!-- Microsoft.Bcl.Build workaround https://github.com/nunit/nunit/issues/2663 -->
     <SkipValidatePackageReferences>true</SkipValidatePackageReferences>
-
-    <!-- Suppress Microsoft.NET.Sdk.WindowsDesktop warning that netcoreapp2.1 doesn't support desktop applications -->
-    <!--<MSBuildWarningsAsMessages Condition="'$(TargetFramework)' == 'netcoreapp2.1'">$(MSBuildWarningsAsMessages);NETSDK1105</MSBuildWarningsAsMessages>-->
   </PropertyGroup>
 
   <!-- Decide if we can use windows forms and wpf -->


### PR DESCRIPTION
This enables usage of platform specific sdk for winforms and wpf by conditionally choosing the sdk.
This should also be future proof for things like .net 5.